### PR TITLE
Add flexible timeouts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,9 @@ pipeline {
 
     stages {
 	stage('Preparing input') {
+        options {
+            timeout(time: 20, unit: 'MINUTES')
+        }
 	    steps {
 		script {
 		    kojiBuildId = params.KOJI_BUILD_ID.toInteger()
@@ -66,6 +69,9 @@ pipeline {
 	    }
 	}
 	stage('Rebuild') {
+        options {
+            timeout(time: 3, unit: 'HOURS')
+        }
 	    environment {
 		KOJI_KEYTAB = credentials('fedora-keytab')
 	    }


### PR DESCRIPTION
Better to have timeouts for each step in a pipeline then wait for the whole steps.
@bookwar,  please, take a look if you are Ok with this numbers.