### PR TITLE
Run on static node.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,14 +4,6 @@
 
 import org.fedoraproject.jenkins.koji.Koji
 
-def podYAML = """
-spec:
-  containers:
-  - name: koji
-    image: quay.io/bookwar/koji-client:0.0.1
-    tty: true
-"""
-
 def pipelineMetadata = [
     pipelineName: 'eln-build',
     pipelineDescription: 'Rebuild Fedora Rawhide package in the ELN Buildroot',
@@ -36,12 +28,7 @@ pipeline {
 	throttle(['eln-build'])
     }
 
-    agent {
-	kubernetes {
-	    yaml podYAML
-	    defaultContainer 'koji'
-	}
-    }
+    agent { label 'static' }
 
     parameters {
 	string(


### PR DESCRIPTION
Reasons:

* ELN code are very high loaded.
* K8S requires additional cleanup containers in Error state.
* We have issues with scaling resources in AWS EKS.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>